### PR TITLE
Chore - Add Git Log Permission

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,7 @@
       "Bash(git *)",
       "Bash(git * && *)",
       "Bash(git status && git log *)",
+      "Bash(git status && git log origin/$(git branch --show-current)..HEAD)",
       "Bash(git -C * worktree *)",
       "Bash(WORKTREE=* && MAIN=* && git -C * worktree *)",
       "Bash(gh *)",


### PR DESCRIPTION
Auto-created draft PR from `chore/add-git-log-permission` → `dev`

**Last updated**: 2026-03-18 after new commits